### PR TITLE
Set cookiepath to suburl

### DIFF
--- a/i18n.go
+++ b/i18n.go
@@ -149,7 +149,7 @@ func I18n(options ...Options) macaron.Handler {
 
 		// Save language information in cookies.
 		if !hasCookie {
-			ctx.SetCookie("lang", curLang.Lang, 1<<31-1, "/")
+			ctx.SetCookie("lang", curLang.Lang, 1<<31-1, "/" + strings.TrimPrefix(opt.SubURL, "/"))
 		}
 
 		restLangs := make([]LangType, 0, i18n.Count()-1)


### PR DESCRIPTION
Set cookiepath to suburl instead of domain root so the cookie won't be sent to other applications running on the same domain.
